### PR TITLE
Add Replace Manual Entry Text option

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,7 +55,7 @@ function setupSidebarObserver() {
 
   container = document.querySelector('.sidebar__body')
   observer = new window.MutationObserver(function(mutations) {
-    var observationDelay;
+    var observationDelay, dateString;
 
     observer.disconnect();
     sidebarChangeCount += 1;
@@ -83,6 +83,12 @@ function setupSidebarObserver() {
     }
     if (OPTIONS.hideNetWorth) {
       hideNetWorth();
+    }
+    if (OPTIONS.replaceManualEntryText) {
+      dateString = new Date().toLocaleDateString('en-us'); // m/d/yyyy. Personal Capital is a U.S. only product.
+      document.querySelectorAll(".sidebar-account.normal div.manual-entry__text").forEach(function(element) {
+        element.innerHTML = dateString;
+      })
     }
     if (sidebarChangeCount > 3) {
       observationDelay = 500;

--- a/options.html
+++ b/options.html
@@ -70,7 +70,7 @@
           </div>          <div>
             <input id="replaceManualEntryText" type="checkbox" />
             <label for="replaceManualEntryText">
-              <span class="checkboxtext">Replace manual account time</span>
+              <span class="checkboxtext">Replace manual entry text</span>
             </label>
             <span class="helptext">
               Replace the "Manual Entry" text with the current date for each manual account in the sidebar.

--- a/options.html
+++ b/options.html
@@ -67,7 +67,8 @@
               Hide the net worth in the sidebar. Useful for keeping sensitive info hidden from
               prying eyes. Hover over net worth to see original value.
             </span>
-          </div>          <div>
+          </div>
+          <div>
             <input id="replaceManualEntryText" type="checkbox" />
             <label for="replaceManualEntryText">
               <span class="checkboxtext">Replace manual entry text</span>

--- a/options.html
+++ b/options.html
@@ -67,6 +67,15 @@
               Hide the net worth in the sidebar. Useful for keeping sensitive info hidden from
               prying eyes. Hover over net worth to see original value.
             </span>
+          </div>          <div>
+            <input id="replaceManualEntryText" type="checkbox" />
+            <label for="replaceManualEntryText">
+              <span class="checkboxtext">Replace manual account time</span>
+            </label>
+            <span class="helptext">
+              Replace the "Manual Entry" text with the current date for each manual account in the sidebar.
+              This makes the last updated account times easier to read.
+            </span>
           </div>
         </div>
         <hr />

--- a/options.js
+++ b/options.js
@@ -9,6 +9,7 @@ function save_options() {
   OPTIONS.condenseBalances = document.getElementById('condenseBalances').checked;
   OPTIONS.hideBackgroundGraphs = document.getElementById('hideBackgroundGraphs').checked;
   OPTIONS.hideNetWorth = document.getElementById('hideNetWorth').checked;
+  OPTIONS.replaceManualEntryText = document.getElementById('replaceManualEntryText').checked;
 
   chrome.storage.sync.set({ 'options': OPTIONS });
   status = document.getElementById('status');
@@ -26,7 +27,8 @@ function restore_options() {
         sortBalances: true,
         condenseBalances: true,
         hideBackgroundGraphs: false,
-        hideNetWorth: false
+        hideNetWorth: false,
+        replaceManualEntryText: false
       };
     }
     OPTIONS = obj.options;
@@ -35,6 +37,7 @@ function restore_options() {
     document.getElementById('condenseBalances').checked = obj.options.condenseBalances;
     document.getElementById('hideBackgroundGraphs').checked = obj.options.hideBackgroundGraphs;
     document.getElementById('hideNetWorth').checked = obj.options.hideNetWorth;
+    document.getElementById('replaceManualEntryText').checked = obj.options.replaceManualEntryText;
   });
 }
 document.addEventListener('DOMContentLoaded', restore_options);


### PR DESCRIPTION
Previously, the last updated account time for manually managed accounts was shown as the current m/d/yyyy date. After a recent update, they are now shown as "Manual Entry" with a small info icon to the right. This is visually very distracting and adds no additional value to me as a user. 

To address this, I've added a new option (default false) that replaces the "Manual Entry" text with the m/d/yyyy formatted date. 

I chose m/d/yyyy over "Just now" because the latter grabs user attention by implying that there is newly imported data to view, but this is never (generally, unless you use some plugin like [pfcrypto](https://github.com/sclem/pfcrypto)) the case for manual accounts as there is no new external data to import.

NOTE: the date text that replaces the "Manual Entry" text will not update for the current date until the next sidebar mutation occurs, which may be similar to the previous behavior. I don't remember if the last updated date for manual accounts updated instantly on day change or not and this probably isn't that important anyway.


Before:
![image](https://github.com/AMeng/personal_capital_plus/assets/918701/b4738f84-d73d-48a1-a6f0-08956ea5670d)

After:
![image](https://github.com/AMeng/personal_capital_plus/assets/918701/d82c5e98-46b8-4114-8a74-a9b307995213)

Options page:
![image](https://github.com/AMeng/personal_capital_plus/assets/918701/ef8209d8-e545-4f46-8880-c8aa0166659c)
