### PR TITLE
Add FireFox Add-on ID

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,5 +14,11 @@
     "matches": ["*://*.personalcapital.com/*"]
   }],
   "permissions": ["storage", "activeTab", "webNavigation"],
-  "host_permissions": ["*://*.personalcapital.com/*"]
+  "host_permissions": ["*://*.personalcapital.com/*"],
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "@personal-capital-plus"
+    }
+  }
 }


### PR DESCRIPTION
FireFox requires an add-on ID for using `storage` permission (https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/).

Chrome does not support `browser_specific_settings`, but ignores it without any errors.

Validated on both Chrome and FireFox locally.

Fixes #13 